### PR TITLE
Use html.(un)escape on python3

### DIFF
--- a/escapes.py
+++ b/escapes.py
@@ -2,8 +2,10 @@
 
 try:
     # python 2
+    # html.escape from HTMLParser
     from HTMLParser import HTMLParser
+    html = HTMLParser()
 except ImportError:
     # python 3
-    from html.parser import HTMLParser
-html = HTMLParser()
+    # html.escape directly available
+    import html


### PR DESCRIPTION
Restore successful `pytest` on python 3.10 by exporting the html module directly instead of looking for an `unescape` method on the `HTMLParser` object, which isn't available.